### PR TITLE
Fix discrepancy with `can_flip` for rlbot v5

### DIFF
--- a/rlgym_compat/car.py
+++ b/rlgym_compat/car.py
@@ -106,6 +106,7 @@ class Car:
             not self.has_double_jumped
             and not self.has_flipped
             and self.air_time_since_jump < DOUBLEJUMP_MAX_DELAY
+            and not self.on_ground
         )
 
     @property


### PR DESCRIPTION
In RLGym-PPO, can_flip is 0 while the car is on the ground. This was not the case in this rlgym_compat, making my bot play weirdly.